### PR TITLE
add astroquery prerelease dependency

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -21,5 +21,7 @@ dependencies:
   - matplotlib # for tudatpy.plotting
   - tqdm       # for tudatpy.trajectory_design.porkchop
   - astropy    # for tudatpy.data.mpc
-  - astroquery # for tudatpy.data.mpc
   - astropy-healpix  # for tudatpy.data._biases
+  - pip
+  - pip:
+    - astroquery==0.4.8.dev9321 # for tudatpy.data.mpc


### PR DESCRIPTION
The following PR adds the specific astroquery pre-release package version to the `environment.yaml` file, as discussed in private conversation.