### PR TITLE
vscode configuration and output file for python build script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,55 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+AllowShortFunctionsOnASingleLine: Empty
+
+NamespaceIndentation: None
+
+BraceWrapping:
+  AfterNamespace: true
+  AfterFunction: true
+  AfterControlStatement: true
+  AfterClass: true
+  SplitEmptyFunction: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+
+AlignAfterOpenBracket: Align
+AlignOperands: false
+
+BreakBeforeBraces: Custom
+
+BinPackParameters: false
+BinPackArguments: false
+Cpp11BracedListStyle: false
+
+PointerAlignment: Left
+
+SpacesInContainerLiterals: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: false
+
+AllowAllParametersOfDeclarationOnNextLine: false
+
+CommentPragmas: '^!|^@'
+SpaceAfterTemplateKeyword: false
+SpacesInTemplateDeclarations: true
+
+ContinuationIndentWidth: 8
+ConstructorInitializerIndentWidth: 4
+BreakConstructorInitializers: AfterColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+
+SpacesInAngles: true
+SpacesInParentheses: true
+SpacesInSquareBrackets: true
+SpaceInEmptyParentheses: true
+SpaceInEmptySquareBrackets: true
+SpaceInEmptyBlock: true
+
+ColumnLimit: 100
+---

--- a/README.md
+++ b/README.md
@@ -149,6 +149,145 @@ recommended to start at `-j2` and work your way up with further builds, ensuring
 
 9. `Build > Build Project`
 
+### Alternative build: VSCode
+
+This section explains how to configure VSCode with CMake presets to build and manage your `tudat` build. The configuration supports parallel builds, switching between Debug and Release modes, enabling/disabling tests, and cleaning build directories. 
+
+#### Requirements
+
+1. **VSCode** with the following extensions:
+   - [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
+   - [C++ Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
+   
+2. **CMake** installed on your system (minimum version 3.19).
+   
+3. **Conda** environment for managing dependencies.
+
+4. **Make/Ninja** installed based on your operating system for build generation.
+
+#### Steps to Configure VSCode
+
+1. **Create the `CMakePresets.json` file** in the root directory of your project. Use the following template with necessary adjustments:
+
+```json
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "hidden": false,
+      "generator": "Unix Makefiles", // Set this based on the OS: "Unix Makefiles" for Linux/macOS, "Ninja" or "Visual Studio" for Windows
+      "binaryDir": "${sourceDir}/build", // Build directory
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "/path/to/your/conda/environment", // <--- CHANGE THIS: Set this to your conda environment or other toolchain path
+        "CMAKE_INSTALL_PREFIX": "/path/to/your/conda/environment", // <--- CHANGE THIS
+        "CMAKE_CXX_STANDARD": "14", // The C++ standard to use
+        "Boost_NO_BOOST_CMAKE": "ON", // Ensures that the system-installed Boost CMake files are not used
+        "CMAKE_BUILD_TYPE": "Release", // Default to Release build
+        "TUDAT_BUILD_TESTS": "ON" // Set to ON to build tests by default
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "default",
+      "description": "Debug build configuration",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug" // Use Debug mode for this preset
+      }
+    },
+    {
+      "name": "no-tests",
+      "inherits": "default",
+      "description": "Build without tests",
+      "cacheVariables": {
+        "TUDAT_BUILD_TESTS": "OFF" // Disable test building in this preset
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "hidden": false,
+      "configurePreset": "default", // Use the default configuration preset
+      "jobs": 8, //<--- CHANGE THIS: Parallel build with N cores
+      "targets": [
+        "all" // Build the default target (usually all)
+      ]
+    },
+    {
+      "name": "debug-build",
+      "configurePreset": "debug", // Use the debug configuration preset
+      "jobs": 8, //<--- CHANGE THIS: Parallel build with N cores
+      "targets": [
+        "all"
+      ]
+    },
+    {
+      "name": "build-no-tests",
+      "configurePreset": "no-tests", // Use the no-tests configuration preset
+      "jobs": 8, //<--- CHANGE THIS: Parallel build with N cores
+      "targets": [
+        "all"
+      ]
+    },
+    {
+      "name": "clean",
+      "configurePreset": "default",
+      "jobs": 8, //<--- CHANGE THIS: Parallel build with N cores
+      "targets": [
+        "clean" // Run the clean target
+      ]
+    }
+  ]
+}
+```
+
+##### Comments on the Configuration
+
+- **CMAKE_PREFIX_PATH**: Set the `CMAKE_PREFIX_PATH` and `CMAKE_INSTALL_PREFIX` to your `tudat-bundle` environment. This is critical to ensure CMake can find the necessary libraries and dependencies.
+  
+- **Generator**: Depending on your OS, the generator should be:
+  - `"Unix Makefiles"` for **macOS** and **Linux**.
+  - `"Ninja"` for **Windows** (if Ninja is installed).
+  - `"Visual Studio"` for **Windows** if using Visual Studio.
+
+- **Parallel Jobs**: The `jobs` key is used to specify the number of jobs for parallel builds. Set the number of cores to be used for the build.
+
+- **Presets**:
+  - `default`: Builds the project in Release mode with tests.
+  - `debug`: Builds the project in Debug mode.
+  - `no-tests`: Builds the project without tests.
+  - `clean`: Cleans the build directory.
+
+#### How to Use Presets in VSCode
+
+1. **Open VSCode** in your project directory.
+   
+2. Open the Command Palette (`F1` or `Ctrl+Shift+P`) and run the command `CMake: Select Configure Preset`.
+
+3. Choose one of the configure presets:
+   - `default`: for Release builds.
+   - `debug`: for Debug builds.
+   - `no-tests`: to skip building tests.
+
+4. Once configured, run the command `CMake: Select Build Preset` from the Command Palette, and choose one of the build presets:
+   - `default`: to build the project.
+   - `debug-build`: to build in Debug mode.
+   - `build-no-tests`: to build without tests.
+   - `clean`: to clean the build directory.
+
+5. To start the build, run `CMake: Build` from the Command Palette or use the build button in the status bar.
+
+#### Troubleshooting
+
+- **CMake Errors**: If CMake cannot find dependencies, check that the `CMAKE_PREFIX_PATH` and `CMAKE_INSTALL_PREFIX` are set correctly in the `CMakePresets.json` file.
+- **Wrong Generator**: If the build fails due to an unsupported generator, change the `"generator"` field in the preset to match your OS and toolchain.
+
 <!--
 The following line can also be edited if you wish to build tudatpy with its debug info (switching from `Release` to `RelWithDebInfo`; note that `Debug` is also available):
 ````

--- a/README.md
+++ b/README.md
@@ -343,6 +343,68 @@ Desired result:
 =========================================== 6 passed in 1.78s ============================================
 ````
 
+## C++ Code Formatting with Clang-Format
+`tudat-bundle` uses `clang-format` to enforce a consistent code style. The configuration file is located in the root of the repository as `.clang-format`.
+
+### Prerequisites
+
+Ensure `clang-format` is installed. You can check the installation by running:
+
+```bash
+clang-format --version
+```
+
+If it's not installed, install `clang-format` using a package manager:
+
+- **On Ubuntu/Debian**: `sudo apt install clang-format`
+- **On macOS**: `brew install clang-format`
+- **On Windows**: Download and install from [LLVM's official site](https://releases.llvm.org/).
+
+### Configuration File
+
+This `.clang-format` file configures formatting settings, including indentation width, brace wrapping, spacing rules, and alignment settings. These settings will ensure your code remains organized, readable, and consistent with `tudat` code style.
+
+### Usage
+
+#### 1. Running Clang-Format on a Single File
+
+To format a single file, run:
+
+```bash
+clang-format -i path/to/your/file.cpp
+```
+
+The `-i` flag formats the file in place.
+
+#### 2. Running Clang-Format on Multiple Files
+
+To format all `.cpp` and `.h` files in your project directory:
+
+```bash
+find path/to/your/project -name '*.cpp' -o -name '*.h' | xargs clang-format -i
+```
+
+Alternatively, if you're using an IDE like Visual Studio Code, you can configure it to automatically format on save.
+
+#### 3. Setting Up Automatic Formatting in VSCode
+
+If you’re using Visual Studio Code, you can automate code formatting:
+
+1. Install the **Clang-Format** extension from the marketplace.
+2. Open your project’s **Settings** (File > Preferences > Settings).
+3. Search for `Clang-Format` and set the path to your `.clang-format` file.
+4. Enable **Format on Save** by setting `"editor.formatOnSave": true` in your `settings.json`.
+
+#### 4. Checking Format Without Applying
+
+To preview formatting changes without modifying files, run:
+
+```bash
+clang-format -output-replacements-xml path/to/your/file.cpp
+```
+
+This will show XML output if there are any format issues. You can then decide to apply formatting manually.
+
 <!-- ## Use your build
 The path of the TudatPy kernel that has been manually compiled needs to be added before importing any `tudatpy.kernel` module.
 This can be done with the following two lines, with `<kernel_path>` being similar to `<tudat-bundle_path>/build/tudatpy`:

--- a/build.py
+++ b/build.py
@@ -1,25 +1,20 @@
+import os
 import sys
+import subprocess
 from pathlib import Path
 from contextlib import chdir
-import subprocess
-import os
 
-
-def usage() -> None:
-    """Print usage information for the script."""
-
-    print("Usage: python build.py [OPTIONS]", end="\n\n")
+def usage():
+    print("Usage: build.py [options]")
     print("Options:")
-    print("  -h | --help                 Show this message")
-    print("  -j                          Number of processors to use [Default: 1]")
-    print("  -c | --clean                Clean after build")
-    print("  --build-dir                 Build directory [Default: build]")
-    print("  --no-tests                  Don't build tests")
-    print("  --cxx-std                   C++ standard for compilation [Default: 14]")
-    print(
-        "  --build-type                Release, Debug, RelWithDebInfo [Default: Release]"
-    )
-
+    print("  -h, --help            Show this help message and exit")
+    print("  -j N                  Number of processors to use")
+    print("  -c, --clean           Clean build")
+    print("  --build-dir DIR       Build directory")
+    print("  --no-tests            Do not build tests")
+    print("  --cxx-std STD         C++ standard to use")
+    print("  --build-type TYPE     Build type (e.g., Release, Debug)")
+    print("  --output-to-file      Output logs to file instead of terminal")
 
 if __name__ == "__main__":
 
@@ -31,6 +26,8 @@ if __name__ == "__main__":
         "RUN_TESTS": True,
         "CXX_STANDARD": "14",
         "BUILD_TYPE": "Release",
+        "OUTPUT_TO_FILE": False,
+        "OUTPUT_FILE": "build/build_output.txt",
     }
     CONDA_PREFIX = os.environ["CONDA_PREFIX"]
 
@@ -52,37 +49,51 @@ if __name__ == "__main__":
             ARGUMENTS["CXX_STANDARD"] = next(args)
         elif arg == "--build-type":
             ARGUMENTS["BUILD_TYPE"] = next(args)
+        elif arg == "--output-to-file":
+            ARGUMENTS["OUTPUT_TO_FILE"] = True
         else:
             print("Invalid command")
             usage()
             exit(1)
 
-    # Ensure build directory exists
-    build_dir = Path(ARGUMENTS["BUILD_DIR"]).resolve()
-    build_dir.mkdir(parents=True, exist_ok=True)
+    # Determine output destination
+    if ARGUMENTS["OUTPUT_TO_FILE"]:
+        output_dest = open(ARGUMENTS["OUTPUT_FILE"], "w")
+    else:
+        output_dest = None
 
-    # Build
-    with chdir(build_dir):
-        outcome = subprocess.run(
-            [
-                "cmake",
-                f"-DCMAKE_PREFIX_PATH={CONDA_PREFIX}",
-                f"-DCMAKE_INSTALL_PREFIX={CONDA_PREFIX}",
-                f'-DCMAKE_CXX_STANDARD={ARGUMENTS["CXX_STANDARD"]}',
-                "-DBoost_NO_BOOST_CMAKE=ON",
-                f'-DCMAKE_BUILD_TYPE={ARGUMENTS["BUILD_TYPE"]}',
-                f'-DTUDAT_BUILD_TESTS={ARGUMENTS["BUILD_TESTS"]}',
-                "..",
-            ]
-        )
-        if outcome.returncode:
-            exit(outcome.returncode)
+    try:
+        # Ensure build directory exists
+        build_dir = Path(ARGUMENTS["BUILD_DIR"]).resolve()
+        build_dir.mkdir(parents=True, exist_ok=True)
 
-        build_command = ["cmake", "--build", "."]
-        if ARGUMENTS["CLEAN_BUILD"]:
-            build_command.append("--target")
-            build_command.append("clean")
-        build_command.append(f"-j{ARGUMENTS['NUMBER_OF_PROCESSORS']}")
-        outcome = subprocess.run(build_command)
-        if outcome.returncode:
-            exit(outcome.returncode)
+        # Build
+        with chdir(build_dir):
+            outcome = subprocess.run(
+                [
+                    "cmake",
+                    f"-DCMAKE_PREFIX_PATH={CONDA_PREFIX}",
+                    f"-DCMAKE_INSTALL_PREFIX={CONDA_PREFIX}",
+                    f'-DCMAKE_CXX_STANDARD={ARGUMENTS["CXX_STANDARD"]}',
+                    "-DBoost_NO_BOOST_CMAKE=ON",
+                    f'-DCMAKE_BUILD_TYPE={ARGUMENTS["BUILD_TYPE"]}',
+                    f'-DTUDAT_BUILD_TESTS={ARGUMENTS["BUILD_TESTS"]}',
+                    "..",
+                ],
+                stdout=output_dest,
+                stderr=output_dest
+            )
+            if outcome.returncode:
+                exit(outcome.returncode)
+
+            build_command = ["cmake", "--build", "."]
+            if ARGUMENTS["CLEAN_BUILD"]:
+                build_command.append("--target")
+                build_command.append("clean")
+            build_command.append(f"-j{ARGUMENTS['NUMBER_OF_PROCESSORS']}")
+            outcome = subprocess.run(build_command, stdout=output_dest, stderr=output_dest)
+            if outcome.returncode:
+                exit(outcome.returncode)
+    finally:
+        if output_dest:
+            output_dest.close()

--- a/build.py
+++ b/build.py
@@ -4,17 +4,23 @@ import subprocess
 from pathlib import Path
 from contextlib import chdir
 
+
 def usage():
     print("Usage: build.py [options]")
     print("Options:")
     print("  -h, --help            Show this help message and exit")
-    print("  -j N                  Number of processors to use")
-    print("  -c, --clean           Clean build")
-    print("  --build-dir DIR       Build directory")
-    print("  --no-tests            Do not build tests")
-    print("  --cxx-std STD         C++ standard to use")
-    print("  --build-type TYPE     Build type (e.g., Release, Debug)")
-    print("  --output-to-file      Output logs to file instead of terminal")
+    print("  -j N                  Number of processors to use [Default: 1]")
+    print("  -c, --clean           Clean build [Default: False]")
+    print("  --build-dir DIR       Build directory [Default: 'build']")
+    print("  --no-tests            Do not build tests [Default: False]")
+    print("  --cxx-std STD         C++ standard to use [Default: 'c++17']")
+    print(
+        "  --build-type TYPE     Build type (e.g., Release, Debug) [Default: 'Release']"
+    )
+    print(
+        "  --output-to-file      Output logs to file instead of terminal [Default: False]"
+    )
+
 
 if __name__ == "__main__":
 
@@ -81,7 +87,7 @@ if __name__ == "__main__":
                     "..",
                 ],
                 stdout=output_dest,
-                stderr=output_dest
+                stderr=output_dest,
             )
             if outcome.returncode:
                 exit(outcome.returncode)
@@ -91,7 +97,9 @@ if __name__ == "__main__":
                 build_command.append("--target")
                 build_command.append("clean")
             build_command.append(f"-j{ARGUMENTS['NUMBER_OF_PROCESSORS']}")
-            outcome = subprocess.run(build_command, stdout=output_dest, stderr=output_dest)
+            outcome = subprocess.run(
+                build_command, stdout=output_dest, stderr=output_dest
+            )
             if outcome.returncode:
                 exit(outcome.returncode)
     finally:


### PR DESCRIPTION

Changes:
- new file:   .clang-format
- modified:   build.py
- modified:   README.md

build.py: Add option to output logs to file and update argument parsing

- Introduced a new argument `--output-to-file` to control whether logs are printed to a file or the terminal.
- Default output file is set to `build/build_output.txt`.
- Updated argument parsing to handle the new `--output-to-file` option.
- Ensured that the output is redirected to the specified file if the `--output-to-file` option is provided, otherwise logs are printed to the terminal.

README.md: Add configuration for VSCode with CMake presets and Clang-format instructions

- Added detailed instructions on how to configure VSCode using CMake presets
- Provided comments and explanations for the `CMakePresets.json` configuration
- Added guidance on selecting build and configure presets in VSCode
- Included troubleshooting tips for common issues related to CMake paths and generators
- instruction to configure and use Clang-formatter