### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd tudat-bundle
 git submodule update --init --recursive
 ```
 
-3. Switch `tudat` and `tudatpy` to the develop branch
+3. Switch `tudat` and `tudatpy` to the desired branch
 
 ```shell
 cd tudat
@@ -64,18 +64,14 @@ cd ../tudatpy
 git checkout develop
 cd ..
 ```
-You don't necessarily have to use the `develop` branches, but we recommend it, as they receive frequent updates, and are the ones used to build the Conda packages.
+We recommend using the [tudatpy/develop](https://github.com/tudat-team/tudatpy/tree/develop), and [tudat/develop](https://github.com/tudat-team/tudat/tree/develop) branches, which are the typical entry point for developers.
 
 4. Create a conda environment with required dependencies
-
-The file `environment.yaml` specifies all the dependencies you will need to work with `tudat` and `tudatpy`
 
 ```shell
 conda env create -f environment.yaml
 conda activate tudat-bundle
 ```
-> [!NOTE]
-> It is possible that the creation of the environment will "time out". A likely reason for this is that some packages cannot be found by the current channel: `conda-forge`. It is then advisable to add the channel `anaconda` to the "channels" list in `environment.yaml` to ensure a proper creation of the environment.
 
 There are several directions you can follow from here. Our recommendation is to use the `build.py` and `install.py` scripts to compile and install the library, as explained below. Have a look at [Alternative build: CLion](#alternative-build-clion), or [Alternative build: VSCode](#alternative-build-vscode) if you prefer to use those tools instead.
 
@@ -119,52 +115,44 @@ ctest
 If all the tests are passing, your libraries are ready to use! Otherwise, feel free to reach us by asking a question on [installation support](https://github.com/orgs/tudat-team/discussions/categories/installation).
 
 ## Alternative build: CLion
+
 > [!NOTE]
-> - [**Windows Users ∩ CLion Users**] In CLion, be sure to set WSL as your Toolchain
->  in `File>Settings>Build, Execution, Deployment>Toolchains`.
->
-> - [**CLion Users**] In CLion, the convention to set CMake arguments
->  is to add them to `File>Settings>Build, Execution, Deployment>CMake Options`.
+> **Windows users:** Be sure to set WSL as your Toolchain in `File>Settings>Build, Execution, Deployment>Toolchains`.
 
 5. Open CLion, create a new project from `File > New Project` and select the directory that has been cloned under bullet
    point 1 (named `tudat-bundle`).
 
-> [!NOTE]
-> To avoid issues with CLion, the directory of the project should correspond exactly to the cloned directory named  `tudat-bundle`.
-
-
 6. Create a build profile in `File > Settings > Build, Execution, Deployment > CMake`.
-> [!NOTE]
-> The CMake configuration option `CMAKE_BUILD_TYPE` will be determined by the the build profile's `Build type` entry.
-> A `Release` configuration will suppress a significant amount of harmless warnings during compilation. Currently,
-> with the move to a later version of boost, some warnings have cropped up that have either not been fixed in the
-> source code, or have not been suppressed via `tudat/cmake_modules/compiler.cmake`.
 
 7. Add the CMake configuration to the `File > Settings > Build, Execution, Deployment > CMake > CMake options` text box:
 
-```
+```shell
 -DCMAKE_PREFIX_PATH=<CONDA_PREFIX>
 -DCMAKE_CXX_STANDARD=14
 -DBoost_NO_BOOST_CMAKE=ON
 ```
 
 The `CONDA_PREFIX` may be determined by activating the environment installed in step 4 and printing its value:
-````
+```shell
 conda activate tudat-bundle && echo $CONDA_PREFIX
-````
-
-The following line can also be edited if you wish to build tudatpy with its debug info (switching from `Release` to `RelWithDebInfo`; note that `Debug` is also available):
-````
--DCMAKE_BUILD_TYPE=RelWithDebInfo
-````
+```
 
 [**Optional**] Add `-j<n>` to `File > Settings > Build, Execution, Deployment > CMake > Build options` to use multiple
-processors. It is likely that if you use all of your processors, your build will freeze your PC indefinitely. It is
-recommended to start at `-j2` and work your way up with further builds, ensuring **no unsaved work** in the background.
+processors (note that each core may take up to 4 GB of RAM, if the compilation is killed prematurely, rerun the above command with a smaller number of cores).
 
 8. In the source tree on the left, right click the top level `CMakeLists.txt` then `Load/Reload CMake Project`.
 
-9. `Build > Build Project`
+9. In the top menu, select `Build > Build Project` to compile tudat with the selected settings.
+
+10. To use your manually compiled `tudatpy` kernel in your Python script, set:
+
+```
+import sys
+sys.path.insert(0, "<build_directory>/tudatpy/")
+sys.path.insert(0, "<build_directory>/../tudatpy/src/tudatpy/)
+```
+
+replacing `<build_directory>` with the full path of your build directory for the project.
 
 ## Alternative build: VSCode
 

--- a/README.md
+++ b/README.md
@@ -1,116 +1,125 @@
 # tudat-bundle
 
-This repository facilitates parallel development between the `tudat` (C++) and the
-`tudatpy` (Python) library.
-Specific indications for documenting `tudat` or `tudapy` are reported in the `tudat-multidoc/README.md` file.
+This repository facililates parallel development of `tudat` and `tudatpy` by allowing you to easily download the two libraries, building them from source, and installing them in your Conda environment.
 
-Please note that for normal usage, we recommend the use of our **conda packages**. For more details on the project, we refer to the [project website](https://docs.tudat.space/en/latest/) and our [project Github page](https://github.com/tudat-team).
+> [!NOTE]
+> If you just want to use the default version of `tudat` and `tudatpy`, we recommend installing our [conda packages](https://anaconda.org/tudat-team/repo)
 
-## Structure of the `tudat-bundle`
+For developer documentation, check the [tudat](https://github.com/tudat-team/tudat/wiki) and [tudatpy](https://github.com/tudat-team/tudatpy/wiki) wikis. For more details about the project, check our [website](https://docs.tudat.space/en/latest/), and our [Github page](https://github.com/tudat-team).
 
-The `tudat-bundle` comprises the following repositories:
+## Contents of `tudat-bundle`
 
+The `tudat-bundle` repository contains the following items:
+- `tudat`: The C++ source code of the library.
+- `tudatpy`: The source code of the Python interface for the library.
+- `build.py`: Build tudat and tudatpy from source.
+- `install.py`: Install tudat and tudatpy in your Conda environment.
+- `uninstall.py`: Remove tudat and tudatpy from your conda environment.
+- `environment.yaml`: The file from which you can create your conda environment.
+
+The remaiming files and directories are for configuration purposes.
+
+<!-- The `tudat-bundle` comprises the following repositories:
 - `tudat`, where the tudat source code is located (this is a separate git repository);
-- `tudatpy`, where the tudatpy binding code is located (this is a separate git repository);
+- `tudatpy`, where the tudatpy binding code is located (this is a separate git repository); -->
 <!-- - `cli`, where the Python Command Line Interface scripts to build the API are located; -->
-
+<!--
 In addition, once the project is built, all the build output will be dumped in the `cmake-build-debug` directory, which
 is not tracked by Git. If the API is also built, more untracked directories will appear, but this is explained in the
-`tudat-multidoc/README.md` file.
+`tudat-multidoc/README.md` file. -->
 
 ## Prerequisites
 
-- [**Windows Users**] Windows Subsystem for Linux ([WSL](https://docs.microsoft.com/en-us/windows/wsl/install))
-  - All procedures, including the following prerequisite, assume the use of WSL. Power users who wish to do otherwise,
-    must do so at their own risk, with reduced support from the team.
-  - Note that WSL is a, partially separated, Ubuntu terminal environment for Windows. Anaconda/Miniconda, Python and any other dependencies you require while **executing code** from the `tudat-bundle`, must be installed in its Linux version via the Ubuntu terminal. This does not apply to PyCharm/CLion however, which can be configured to compile and/or run Python code through the WSL.
-  - Note that, to access files and folders of WSL directly in Windows explorer, one can type `\\wsl$` or `Linux` in the Windows explorer access bar, then press enter.
-  - At the opposite, please follow [this guide](https://docs.microsoft.com/en-us/windows/wsl/wsl2-mount-disk) to access Windows file trough WSL.
-  - [This guide from Microsoft](https://docs.microsoft.com/en-us/windows/wsl/setup/environment) contains more information on the possibilities given trough WSL.
-  - In the Ubuntu terminal environment under WSL, run the command `sudo apt-get install build-essential` to install the necessary compilation tools
-- Anaconda/Miniconda installation ([Installing Anaconda](https://tudat-space.readthedocs.io/en/latest/_src_first_steps/tudat_py.html#installing-anaconda))
-- CMake installation
-  - Inside the Ubuntu terminal, install CMake by calling `sudo apt install cmake`.
+> [!NOTE]
+> **For windows users only**
+> The steps in this guide assume the use of Windows Subsystem for Linux (WSL). Have a look at the [Setting up WSL for tudat development](#setting-up-wsl-for-tudat-development) section before proceeding with the next steps.
+
+- Conda: How to install [Anaconda](https://docs.anaconda.com/anaconda/install/) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
+- CMake: You can run `conda install cmake` on your terminal.
+- Git: You can run `conda install git` on your terminal.
+
+<!-- Do the conda install options work? -->
 
 ## Setup
 
 1. Clone the repository and enter directory
 
-````
+```shell
 git clone https://github.com/tudat-team/tudat-bundle
 cd tudat-bundle
-````
+```
 
-> **Note** \
-> The `tudat-bundle` repository uses git submodules, which "allow you to keep a Git repository as a subdirectory of
-> another Git repository" (from [the Git guide](https://git-scm.com/book/en/v2/Git-Tools-Submodules)). In particular,
-> in the `tudat-bundle` there are four different subdirectories that are separate repositories: `tudat`, `tudatpy`,
-> `tudat-multidoc` and `tudat-multidoc/multidoc`. Each repository has its own branches and functions separately from
-> the others. This is the reason why the following two steps are needed.
+2. Clone the `tudat` and `tudatpy` submodules
 
-2. Clone the `tudat` & `tudatpy` submodules
-
-````
+```shell
 git submodule update --init --recursive
-````
+```
 
-3. Switch `tudat` & `tudatpy` to their desired branches using
+3. Switch `tudat` and `tudatpy` to the develop branch
 
-````
+```shell
 cd tudat
 git checkout develop
-cd ..
-cd tudatpy
+cd ../tudatpy
 git checkout develop
-````
-We recommend working with the `develop` branches ([tudatpy/develop](https://github.com/tudat-team/tudatpy/tree/develop), [tudat/develop](https://github.com/tudat-team/tudat/tree/develop)), as they receive frequent updates and are the ones used to build the Conda packages.
-
-4. Install the contained `environment.yaml` file to satisfy dependencies
-
-````
-conda env create -f environment.yaml
-````
-
-It is possible that the creation of the environment will 'time out'. A likely reason for this is that the packages required cannot be found by the current channel, `conda-forge`. It is then advisable to add the channel `anaconda` to ensure a proper creation of the environment.
-
-There are two directions you can go from here: the command line or CLion.
-
-### Build & Install: Command line
-
-5. Activate the conda environment
-
-````
-conda activate tudat-bundle
-````
-
-6. Build Tudat and TudatPy
-
+cd ..
 ```
+You don't necessarily have to use the `develop` branches, but we recommend it, as they receive frequent updates, and are the ones used to build the Conda packages.
+
+4. Create a conda environment with required dependencies
+
+The file `environment.yaml` specifies all the dependencies you will need to work with `tudat` and `tudatpy`
+
+```shell
+conda env create -f environment.yaml
+conda activate tudat-bundle
+```
+> [!NOTE]
+> It is possible that the creation of the environment will "time out". A likely reason for this is that some packages cannot be found by the current channel: `conda-forge`. It is then advisable to add the channel `anaconda` to the "channels" list in `environment.yaml` to ensure a proper creation of the environment.
+
+There are several directions you can follow from here. Our recommendation is to use the `build.py` and `install.py` scripts to compile and install the library, as explained below. Have a look at [Alternative build: CLion](#alternative-build-clion), or [Alternative build: VSCode](#alternative-build-vscode) if you prefer to use those tools instead.
+
+5. Compile Tudat and TudatPy
+
+```shell
 python build.py -h                   # Show help and available flags
 python build.py -j<number-of-cores>  # Compile tudat and tudatpy
 ```
-This script compiles tudat and tudatpy. It will take some time to execute, but you can speed up the process by increasing the number of cores used with the `-j` flag.
+This script compiles tudat and tudatpy. It will take some time to execute, but you can speed up the process by using the `-j` flag, and replacing `<number-of-cores>` with the number of cores you want to use.
 
-7. Install
+6. Install
 
-```
+```shell
 python install.py -h                 # Show help and available flags
 python install.py -e                 # Install in "editable mode"
 ```
-This script installs tudat and tudatpy in your active conda environment. If you install with the `-e` flag, you will not have to re-install every time you update the source code of the libraries.
+This script installs tudat and tudatpy in your active conda environment. If you don't call it with the `-e` flag, you will have to re-run it every time you modify the source code, so we don't recommend it.
 
 And that's it! The next step shows you what to do if you want to uninstall the libraries.
 
-8. Uninstall
+7. Uninstall
 
-```
+```shell
 python uninstall.py -h                # Show help and available flags
 python uninstall.py                   # Uninstall tudat and tudatpy
 ```
 This script will remove tudat and tudatpy from your Conda environment, but it will not delete the build directory.
 
-### Alternative build: CLion
-> **Note**
+### Verify your installation
+
+It is a good idea to verify that your installation is working by running the `tudatpy` tests. If you are in the `tudat-bundle` directory, you can do this by running
+```shell
+pytest
+```
+If you built tudat with the `--tests` flag (which is turned off by default), you can also run the tudat tests as follows
+```shell
+cd build/tudat
+ctest
+```
+If all the tests are passing, your libraries are ready to use! Otherwise, feel free to reach us by asking a question on [installation support](https://github.com/orgs/tudat-team/discussions/categories/installation).
+
+## Alternative build: CLion
+> [!NOTE]
 > - [**Windows Users ∩ CLion Users**] In CLion, be sure to set WSL as your Toolchain
 >  in `File>Settings>Build, Execution, Deployment>Toolchains`.
 >
@@ -119,12 +128,13 @@ This script will remove tudat and tudatpy from your Conda environment, but it wi
 
 5. Open CLion, create a new project from `File > New Project` and select the directory that has been cloned under bullet
    point 1 (named `tudat-bundle`).
-> **Note** \
+
+> [!NOTE]
 > To avoid issues with CLion, the directory of the project should correspond exactly to the cloned directory named  `tudat-bundle`.
 
 
 6. Create a build profile in `File > Settings > Build, Execution, Deployment > CMake`.
-> **Note** \
+> [!NOTE]
 > The CMake configuration option `CMAKE_BUILD_TYPE` will be determined by the the build profile's `Build type` entry.
 > A `Release` configuration will suppress a significant amount of harmless warnings during compilation. Currently,
 > with the move to a later version of boost, some warnings have cropped up that have either not been fixed in the
@@ -156,11 +166,11 @@ recommended to start at `-j2` and work your way up with further builds, ensuring
 
 9. `Build > Build Project`
 
-### Alternative build: VSCode
+## Alternative build: VSCode
 
 This section explains how to configure VSCode with CMake presets to build and manage your `tudat` build. The configuration supports parallel builds, switching between Debug and Release modes, enabling/disabling tests, and cleaning build directories.
 
-#### Requirements
+### Requirements
 
 1. **VSCode** with the following extensions:
    - [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
@@ -172,7 +182,7 @@ This section explains how to configure VSCode with CMake presets to build and ma
 
 4. **Make/Ninja** installed based on your operating system for build generation.
 
-#### Steps to Configure VSCode
+### Steps to Configure VSCode
 
 1. **Create the `CMakePresets.json` file** in the root directory of your project. Use the following template with necessary adjustments:
 
@@ -254,7 +264,7 @@ This section explains how to configure VSCode with CMake presets to build and ma
 }
 ```
 
-##### Comments on the Configuration
+#### Comments on the Configuration
 
 - **CMAKE_PREFIX_PATH**: Set the `CMAKE_PREFIX_PATH` and `CMAKE_INSTALL_PREFIX` to your `tudat-bundle` environment. This is critical to ensure CMake can find the necessary libraries and dependencies.
 
@@ -271,7 +281,7 @@ This section explains how to configure VSCode with CMake presets to build and ma
   - `no-tests`: Builds the project without tests.
   - `clean`: Cleans the build directory.
 
-#### How to Use Presets in VSCode
+### How to Use Presets in VSCode
 
 1. **Open VSCode** in your project directory.
 
@@ -290,7 +300,7 @@ This section explains how to configure VSCode with CMake presets to build and ma
 
 5. To start the build, run `CMake: Build` from the Command Palette or use the build button in the status bar.
 
-#### Troubleshooting
+### Troubleshooting
 
 - **CMake Errors**: If CMake cannot find dependencies, check that the `CMAKE_PREFIX_PATH` and `CMAKE_INSTALL_PREFIX` are set correctly in the `CMakePresets.json` file.
 - **Wrong Generator**: If the build fails due to an unsupported generator, change the `"generator"` field in the preset to match your OS and toolchain.
@@ -312,43 +322,22 @@ NUMBER_OF_PROCESSORS=${number_of_processors:-2}
 bash build.sh
 ```` -->
 
-## Verify your build
 
-### Running `tudat` tests
 
-1. Enter the `tudat` build directory
-````
-cd <build_directory>/tudat
-````
+## Setting up WSL for tudat development
 
-2. Run the tests using `ctest` (packaged with CMake)
-````
-ctest
-````
+The Windows Subsystem for Linux (WSL) is a tool that allows you to set up an Ubuntu terminal in a Windows computer. This will be the terminal you will use to interact with `tudat` and `tudatpy`, and the one in which Conda, CMake, git... should be installed. Here, you can find some tips about WSL for tudat development.
 
-Desired result:
-````
-..
-100% tests passed, 0 tests failed out of 224
-Total Test time (real) = 490.77 sec
-````
+- Follow the [Microsoft Guide](https://docs.microsoft.com/en-us/windows/wsl/install) to set up WSL.
+- Anaconda/Miniconda, Python and any other dependencies you require while **executing code** from the `tudat-bundle`, must be installed in its Linux version via the Ubuntu terminal. This does not apply to PyCharm/CLion however, which can be configured to compile and/or run Python code through the WSL.
+- Note that, to access files and folders of WSL directly in Windows explorer, one can type `\\wsl$` or `Linux` in the Windows explorer access bar, then press enter.
+- At the opposite, please follow [this guide](https://docs.microsoft.com/en-us/windows/wsl/wsl2-mount-disk) to access Windows file trough WSL.
+- [This guide from Microsoft](https://docs.microsoft.com/en-us/windows/wsl/setup/environment) contains more information on the possibilities given trough WSL.
+- In the Ubuntu terminal environment under WSL, run the command `sudo apt-get install build-essential` to install the necessary compilation tools
 
-### Running `tudatpy` tests
+- Conda: How to install [Anaconda](https://docs.anaconda.com/anaconda/install/) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html)?
+- CMake: You can use `conda install cmake`, or any alternative method.
 
-1. Enter the `tudatpy` build directory
-````
-cd <build_directory>/tudatpy
-````
-
-2. Run the tests using `pytest`
-````
-pytest
-````
-
-Desired result:
-````
-=========================================== 6 passed in 1.78s ============================================
-````
 
 ## C++ Code Formatting with Clang-Format
 `tudat-bundle` uses `clang-format` to enforce a consistent code style. The configuration file is located in the root of the repository as `.clang-format`.


### PR DESCRIPTION
# Rationale
This pull request is associated with #31   and aims at modifying the README to remove outdated information, and make it easier to understand.

# Changelog
- Use Github's [!NOTE] to make notes look better
- Replace "Structure of tudat-bundle" with an equivalent section presenting the relevant files and directories in it
- Move the Windows-specific prerequisites to their own section, which is clearly referenced with a link and a note at the beginning of the "Prerequisites" section. I also replaced the "sudo apt" instructions to install cmake with `conda install cmake`, which makes them operating system independent, and added "git" as a dependency.
- Removed notes from Setup section, and rewrote instructions so that they can be copy-pasted directly into a terminal
- Defined `build.py` as the recommended method to build the libraries, as it is the simplest method (least steps and actions), and will be the only one to integrate stub generation. The CLion and VSCode guidelines are still suggested and clearly referenced in case users prefer them.
- Moved the "Verify your installation" section right under "Setup", to make it more visible and incentivize users to verify their builds. I also added an invitation to post in our discussions page for users having problems with their tests, which should be enough to mark #8 as solved.
- Updated CLion instructions to match #26

> [!NOTE]
> This is my view on how the README should look like. Feel free to suggest modifications!

 