### PR TITLE
Parallel installations in multiple conda environments

### DIFF
--- a/dev/main.py
+++ b/dev/main.py
@@ -1,3 +1,0 @@
-from tudatpy.interface import spice
-
-print(spice.get_total_count_of_kernels_loaded())

--- a/dev/main.py
+++ b/dev/main.py
@@ -1,0 +1,3 @@
+from tudatpy.interface import spice
+
+print(spice.get_total_count_of_kernels_loaded())

--- a/install.py
+++ b/install.py
@@ -105,6 +105,7 @@ class Installer:
                 "using an older version of\nthis script, and you did not "
                 "uninstall it before updating tudat-bundle.\n\n"
                 "Please, have a look at this document before proceeding:\n"
+                "https://github.com/tudat-team/tudat-bundle/wiki/backwards-compatibility"
             )
             exit(0)
 

--- a/install.py
+++ b/install.py
@@ -91,7 +91,9 @@ class Installer:
             )
 
         # Define path to installation manifest
-        self.manifest = self.build_dir / "custom-manifest.txt"
+        self.manifest_dir = self.build_dir / "manifests"
+        self.manifest_dir.mkdir(parents=True, exist_ok=True)
+        self.manifest = self.manifest_dir / f"{self.conda_prefix.name}.txt"
         if self.manifest.exists():
             raise RuntimeError("Delete current manifest before installation")
         # if self.manifest.exists():

--- a/install.py
+++ b/install.py
@@ -94,6 +94,20 @@ class Installer:
         self.manifest_dir = self.build_dir / "manifests"
         self.manifest_dir.mkdir(parents=True, exist_ok=True)
         self.manifest = self.manifest_dir / f"{self.conda_prefix.name}.txt"
+
+        # Backwards compatibility: Check if the old manifest exists
+        old_manifest = self.build_dir / "custom-manifest.txt"
+        if old_manifest.exists():
+            print(
+                "IMPORTANT WARNING:\n"
+                "The installation manifest from an older version of this script"
+                " was found.\nThis probably means that you installed tudatpy "
+                "using an older version of\nthis script, and you did not "
+                "uninstall it before updating tudat-bundle.\n\n"
+                "Please, have a look at this document before proceeding:\n"
+            )
+            exit(0)
+
         if self.manifest.exists():
             raise RuntimeError("Delete current manifest before installation")
         # if self.manifest.exists():

--- a/uninstall.py
+++ b/uninstall.py
@@ -45,15 +45,15 @@ class Remover:
 
         # Resolve installation manifest
         self.manifest_dir = self.build_dir / "manifests"
-        if not self.manifest_dir.exists():
-            raise FileNotFoundError(
-                f"Manifest directory {self.manifest_dir} does not exist."
-            )
         self.manifest = self.manifest_dir / f"{self.conda_prefix.name}.txt"
         if not self.manifest.exists():
-            raise FileNotFoundError(
-                "Installation manifest not found for active conda environment."
-            )
+            # Backwards compatibility: Try to look for the old manifest
+            self.manifest = self.build_dir / "custom-manifest.txt"
+            if not self.manifest.exists():
+                raise FileNotFoundError(
+                    "Installation manifest not found for active "
+                    f"conda environment: {self.conda_prefix.name}"
+                )
 
         return None
 

--- a/uninstall.py
+++ b/uninstall.py
@@ -36,10 +36,24 @@ class Remover:
                 f"Build directory {self.build_dir} does not exist."
             )
 
+        # Resolve conda prefix
+        self.conda_prefix = Path(os.environ["CONDA_PREFIX"])
+        if not self.conda_prefix.exists():
+            raise FileNotFoundError(
+                f"Conda prefix {self.conda_prefix} does not exist."
+            )
+
         # Resolve installation manifest
-        self.manifest = self.build_dir / "custom-manifest.txt"
+        self.manifest_dir = self.build_dir / "manifests"
+        if not self.manifest_dir.exists():
+            raise FileNotFoundError(
+                f"Manifest directory {self.manifest_dir} does not exist."
+            )
+        self.manifest = self.manifest_dir / f"{self.conda_prefix.name}.txt"
         if not self.manifest.exists():
-            raise FileNotFoundError("Installation manifest not found")
+            raise FileNotFoundError(
+                "Installation manifest not found for active conda environment."
+            )
 
         return None
 


### PR DESCRIPTION
# Purpose
The purpose of this PR is to:
- Allow users to install locally built versions of `tudat` and `tudatpy` in multiple conda environments.
- Provide better support for users transitioning from the old version of `tudat-bundle`

# Details

Consider a user building and installing the libraries in a conda environment `A`, and wanting to create a parallel installation in environment `B`. The build directory is called `build`, the *current* version of `tudat-bundle` refers to the one before merging this PR, and the *new*  version refers to the one introduced by this PR.

When run from environment `A`, the current `install.py` script produces a file `build/custom-manifest.txt`, where it lists all the files and directories it added to `A` during the installation. The `uninstall.py` script then parses this file, removes all the listed items, and then removes the file itself to prevent an attempt to remove an uninstalled package. When trying to create a parallel installation in `B`, the `install.py` script overwrites `built/custom-manifest.txt`, making uninstalling the library from `A` with the `uninstall.py` script no longer possible.

With the new version, when run from environment `A`, the `install.py` script produces a file `build/manifests/A.txt`, which is the installation manifest for this environment. When run from environment `B`, the `install.py` script adds a file `build/manifests/B.txt` to the directory. To uninstall the libraries from `B`, the uses activates the environment `B` and runs `uninstall.py`, which removes the items listed in `build/manifests/B.txt` and the manifest itself. This allows for an arbitrary number of parallel installations symlinked to the same build.

# Backwards compatibility

To make the new version of the scripts backwards compatible, I introduced an additional check on the `uninstall.py` script, which tries to fallback to using `build/custom-manifest.txt` if it fails to find a valid manifest for the active environment. This approach is safe, as the correct installation will be removed even if the `uninstall.py` script is called from a different environment.

To provide additional support to users coming from older versions of `tudat-bundle` (before #27), the `install.py` script now fails with the following warning if it detects `build/custom-manifest.txt`, to ensure that the old installation is removed even if it comes from a previous version of `tudat-bundle`:

```
IMPORTANT WARNING:
The installation manifest from an older version of this script was found.
This probably means that you installed tudatpy using an older version of
this script, and you did not uninstall it before updating tudat-bundle.

Please, have a look at this document before proceeding:
https://github.com/tudat-team/tudat-bundle/wiki/backwards-compatibility
```
The link points to a new wiki page with detailed (and simple) instructions on how to remove the old installation without having to start a new conda environment.
