### PR TITLE
Update astroquery to latest stable conda release

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -21,6 +21,7 @@ dependencies:
   - matplotlib # for tudatpy.plotting
   - tqdm       # for tudatpy.trajectory_design.porkchop
   - astropy    # for tudatpy.data.mpc
+  - astroquery>0.4.8 # for tudatpy.data.mpc
   - astropy-healpix  # for tudatpy.data._biases
   - spiceypy # for automatic data downloader and kernel converter
   # Data downloader tabular output
@@ -35,7 +36,6 @@ dependencies:
   # Pip
   - pip
   - pip:
-     - astroquery==0.4.8.dev9321 # for tudatpy.data.mpc
      - nbsphinx
      - sphinxcontrib-napoleon
      - sphinx_rtd_theme


### PR DESCRIPTION
Update astroquery to stable conda release, as the current latest conda version is v.0.4.10.
Fixes #22 