### PR TITLE
Stubs for plotting module

### DIFF
--- a/build.py
+++ b/build.py
@@ -100,7 +100,7 @@ class StubGenerator:
     indentation: str = " " * 4
 
     # Ignored modules and methods
-    ignored_modules: list[str] = ["temp", "io", "plotting"]
+    ignored_modules: list[str] = ["temp", "io"]
     ignored_methods: list[str] = ["_pybind11_conduit_v1_"]
 
     def __init__(self, build_dir: Path) -> None:


### PR DESCRIPTION
This PR adds support for stub generation of the plotting module on the tudat-bundle side, by removing the plotting module from the ignored modules. Together with https://github.com/tudat-team/tudatpy/pull/291 stubs should be generated correctly.

> [!IMPORTANT]
>  https://github.com/tudat-team/tudatpy/pull/291 should be merged before this PR.

Steps to verify:

Checkout PR branches:
```
cd tudat-bundle
git checkout fix/plotting-module-stubs
cd tudatpy && git checkout fix/plotting-module-stubs
cd ..
```

Generate stubs:
```
conda activate tudat-bundle && python build.py --stubs-only
```

Create a new file `test_plotting_module_stubs.py` and paste the following content:
```python
import numpy as np
from tudatpy.plotting import trajectory_3d

fig, ax = trajectory_3d(
    {0: np.array([7000e3, 0, 0, 0, 0, 7.5e3])},
    ["Delfi-C3"],
    "Earth",
    ["Moon"],
    "J2000",
)
fig.show()
```

The `trajectory_3d` function should have autocomplete and docstrings on hover.